### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improved formatting consistency in the GitHub Actions workflow. 🚀  

### 📊 Key Changes  
- Adjusted the comment line to improve formatting by slightly revising the license text.

### 🎯 Purpose & Impact  
- 📝 **Consistency**: Enhances clarity and alignment with Ultralytics' style standards.  
- 🔧 **No user-facing impact**: This is an internal adjustment and does not affect the functionality or performance of the repository.