### PR TITLE
Improve README accuracy and links

### DIFF
--- a/NONNEUTRINOBACKGROUND/MULLISS/predict_cosmogenic_background.m
+++ b/NONNEUTRINOBACKGROUND/MULLISS/predict_cosmogenic_background.m
@@ -111,7 +111,7 @@ likelihood_selection_eff=1;          %0.891 for KL, 1 for Borexino (derived to m
 [muon_intensity_ref,muon_average_energy_ref]=predict_muon_intensity(depth_flat_eq_ref,1);
 [muon_intensity,muon_average_energy]=predict_muon_intensity(depth,type);
 
-%Compute Duty Cycle loss related to muon_DT (applies to all muons passing thru detector)
+%Compute Duty Cycle loss related to muon_DT (applies to all muons passing through detector)
 if fiducial_vol>150000    %Special case to handle SNIF because it's shape is significantly elongated
     muon_cross_section=(2*23*96.5);                         %m^2
 else

--- a/NONNEUTRINOBACKGROUND/MULLISS/predict_cosmogenic_background.m
+++ b/NONNEUTRINOBACKGROUND/MULLISS/predict_cosmogenic_background.m
@@ -111,7 +111,7 @@ likelihood_selection_eff=1;          %0.891 for KL, 1 for Borexino (derived to m
 [muon_intensity_ref,muon_average_energy_ref]=predict_muon_intensity(depth_flat_eq_ref,1);
 [muon_intensity,muon_average_energy]=predict_muon_intensity(depth,type);
 
-%Compute Duty Cycle loss related to muon_DT (applies to all muons passing through detector)
+%Compute Duty Cycle loss related to muon_DT (applies to all muons passing thru detector)
 if fiducial_vol>150000    %Special case to handle SNIF because it's shape is significantly elongated
     muon_cross_section=(2*23*96.5);                         %m^2
 else

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## 🌟 Introduction
 
-Welcome to the NUDAR (Nuclear Detection, Ranging, and Mapping) repository by [Ultralytics](https://www.ultralytics.com/)! This project offers sophisticated simulation tools crafted for modeling the Earth's structure and simulating [neutrino](https://en.wikipedia.org/wiki/Neutrino) detector systems. Grounded in scientific research, our tools cater to both the academic community and applied sciences within [geophysics](https://en.wikipedia.org/wiki/Geophysics) and [particle physics](https://home.cern/science/physics/particle-physics). Explore the fascinating intersection of earth modeling and neutrino detection with NUDAR! 🌍✨
+Welcome to the NUDAR (NeUtrino Detection and Ranging) repository by [Ultralytics](https://www.ultralytics.com/)! This project offers sophisticated simulation tools crafted for modeling the Earth's structure and simulating [neutrino](https://en.wikipedia.org/wiki/Neutrino) detector systems. Grounded in scientific research, our tools cater to both the academic community and applied sciences within [geophysics](https://en.wikipedia.org/wiki/Geophysics) and [particle physics](https://home.cern/science/physics/). Explore the fascinating intersection of earth modeling and neutrino detection with NUDAR! 🌍✨
 
 [![Ultralytics Actions](https://github.com/ultralytics/nudar/actions/workflows/format.yml/badge.svg)](https://github.com/ultralytics/nudar/actions/workflows/format.yml)
 [![Ultralytics Discord](https://img.shields.io/discord/1089800235347353640?logo=discord&logoColor=white&label=Discord&color=blue)](https://discord.com/invite/ultralytics)
@@ -11,9 +11,9 @@ Welcome to the NUDAR (Nuclear Detection, Ranging, and Mapping) repository by [Ul
 
 ## 📜 Description
 
-NUDAR provides a comprehensive suite of [MATLAB](https://www.mathworks.com/products/matlab.html) simulations designed to advance the theoretical study of [antineutrino](https://en.wikipedia.org/wiki/Antineutrino) interactions and detection. This software is instrumental in deepening our understanding of antineutrino properties and their potential applications, such as probing the [Earth's interior](https://education.nationalgeographic.org/resource/encyclopedia/earths-interior/) and enhancing nuclear detection capabilities.
+NUDAR provides a comprehensive suite of [MATLAB](https://www.mathworks.com/products/matlab.html) simulations designed to advance the theoretical study of [antineutrino](https://en.wikipedia.org/wiki/Antineutrino) interactions and detection. This software is instrumental in deepening our understanding of antineutrino properties and their potential applications, such as probing the [Earth's interior](https://pubs.usgs.gov/gip/interior/) and enhancing nuclear detection capabilities.
 
-Our development is inspired by the foundational paper by G. Jocher et al., "Theoretical Antineutrino Detection, Direction and Ranging at Long Distances," published in [Physics Reports](https://www.sciencedirect.com/journal/physics-reports) (Volume 527, Issue 3, 2013). For an in-depth look at the scientific principles underpinning these simulations, please consult the publication via its DOI: [http://dx.doi.org/10.1016/j.physrep.2013.01.005](http://dx.doi.org/10.1016/j.physrep.2013.01.005). You can find more insights into related fields on the [Ultralytics Blog](https://www.ultralytics.com/blog).
+Our development is inspired by the foundational paper by G. Jocher et al., "Theoretical Antineutrino Detection, Direction and Ranging at Long Distances," published in Physics Reports (Volume 527, Issue 3, 2013). For an in-depth look at the scientific principles underpinning these simulations, please consult the publication via its DOI: [https://doi.org/10.1016/j.physrep.2013.01.005](https://doi.org/10.1016/j.physrep.2013.01.005). You can find more insights into related fields on the [Ultralytics Blog](https://www.ultralytics.com/blog).
 
 ![Earth Modeling and Neutrino Detection Simulation](https://github.com/ultralytics/agm2015/blob/main/AGM2015small.jpg)
 
@@ -60,7 +60,7 @@ Contributions from the community are highly encouraged! Whether it's fixing bugs
 
 Ultralytics offers two licensing options for NUDAR:
 
-- **AGPL-3.0 License**: An [OSI-approved](https://opensource.org/license/agpl-3.0/) open-source license ideal for students, researchers, and enthusiasts keen on collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/nudar/blob/main/LICENSE) file for full details.
+- **AGPL-3.0 License**: An [OSI-approved](https://opensource.org/license/agpl-v3) open-source license ideal for students, researchers, and enthusiasts keen on collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/nudar/blob/main/LICENSE) file for full details.
 - **Enterprise License**: Designed for commercial applications, this license permits the integration of NUDAR into commercial products and services without the open-source obligations of AGPL-3.0. For commercial use, please contact us through [Ultralytics Licensing](https://www.ultralytics.com/license).
 
 ## 📬 Contact Us


### PR DESCRIPTION
## Summary
- aligns the NUDAR acronym with repository metadata
- replaces broken CERN and Earth interior links with current durable sources
- uses the DOI directly for the Physics Reports paper and updates the AGPL link

## Validation
- git diff --check
- lychee --accept 200,403 README.md CRUST/crust1.0/readme (MathWorks blocks automated checks with 403)
- CRUST/crust1.0/readme audited; no edits needed

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves `README.md` accuracy by correcting the NUDAR acronym and refreshing several outdated or imprecise reference links. ✨

### 📊 Key Changes
- Corrected the NUDAR expansion from “Nuclear Detection, Ranging, and Mapping” to “NeUtrino Detection and Ranging”.
- Updated the CERN particle physics reference link to a more accurate destination.
- Replaced the Earth’s interior reference with a more authoritative USGS source.
- Simplified the Physics Reports citation text and updated the DOI to the canonical `doi.org` format.
- Fixed the AGPL-3.0 license link to the current Open Source Initiative page.

### 🎯 Purpose & Impact
- Improves README accuracy and reduces confusion for new users and researchers. 📘
- Ensures external references point to more reliable and current sources. 🔗
- Strengthens project credibility by aligning documentation with the actual NUDAR meaning and publication metadata. ✅